### PR TITLE
ci: add Slack failure alerts to all workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,17 @@ jobs:
             --title "v${{ steps.versions.outputs.version }}" \
             --generate-notes \
             --notes-start-tag "v${{ steps.versions.outputs.previous_version }}"
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: always() && contains(needs.*.result, 'failure')
+    steps:
+      - uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "text": "❌ **RELEASE FAILED**\nxpoz-ts@${{ github.sha }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }

--- a/.github/workflows/sync-expectations.yml
+++ b/.github/workflows/sync-expectations.yml
@@ -49,3 +49,17 @@ jobs:
           git commit -m "chore: update TypeScript SDK expectations"
           git push -u origin "$BRANCH" --force
           gh pr create --title "chore: update TypeScript SDK expectations" --body "Auto-generated from xpoz-ts type changes." --base main || true
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [sync]
+    if: always() && contains(needs.*.result, 'failure')
+    steps:
+      - uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "text": "❌ **SYNC EXPECTATIONS FAILED**\nxpoz-ts@${{ github.sha }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,17 @@ jobs:
       - run: npm test
         env:
           XPOZ_API_KEY: ${{ secrets.XPOZ_API_KEY }}
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: always() && contains(needs.*.result, 'failure')
+    steps:
+      - uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "text": "❌ **CI FAILED**\nxpoz-ts@${{ github.sha }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }


### PR DESCRIPTION
## Summary
- Add Slack failure notifications to CI, release, and sync-expectations workflows
- Uses `slackapi/slack-github-action@v2.1.1` with `SLACK_DEPLOYMENT_WEBHOOK_URL` (same pattern as xpoz-mcp)
- Alerts fire when any job in the workflow fails

## Test plan
- [ ] Ensure `SLACK_DEPLOYMENT_WEBHOOK_URL` secret is configured in repo settings
- [ ] Trigger a test failure to verify Slack notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)