### PR TITLE
fix: terminate MCP session before closing transport

### DIFF
--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -54,6 +54,11 @@ export class McpTransport {
   async close(): Promise<void> {
     if (this.client) {
       try {
+        await this.transport?.terminateSession();
+      } catch {
+        // ignore — server may not support session termination (405)
+      }
+      try {
         await this.client.close();
       } catch {
         // ignore errors on close


### PR DESCRIPTION
## Summary
- Calls `terminateSession()` (HTTP DELETE) on the MCP transport **before** `close()` aborts the connection
- Without this, sessions were left as zombies on the server, accumulating against the API key's rate limit
- This caused cascading test failures in CI that got worse on rerun — the server rejected new connections because orphaned sessions were still counted

## Root cause
`close()` called `abortController.abort()` but never sent the HTTP DELETE that the MCP spec requires to end a session. Worse, calling `terminateSession()` *after* `close()` would silently fail because the abort signal was already triggered.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Reproduced failure locally: back-to-back `npm test` runs — 2nd run failed at TikTok/Reddit with `Streamable HTTP error`
- [x] After fix: 3 consecutive `npm test` runs, all 54/54 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)