### PR TITLE
ENG-1584/1585/1586: align TypeScript SDK with MCP wire contract (error + no_data)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,23 +31,38 @@ export class OperationTimeoutError extends XpozError {
   }
 }
 
-export class OperationFailedError extends XpozError {
-  operationId: string;
-  operationError: string;
+export interface OperationFailedErrorParams {
+  error: string;
+  operationId?: string;
+  message?: string;
+  category?: string;
+}
 
-  constructor(operationId: string, error: string) {
-    super(`Operation ${operationId} failed: ${error}`);
+export class OperationFailedError extends XpozError {
+  operationId?: string;
+  operationError: string;
+  errorMessage?: string;
+  category?: string;
+
+  constructor(params: OperationFailedErrorParams) {
+    const prefix = params.operationId
+      ? `Operation ${params.operationId}`
+      : "Operation";
+    super(`${prefix} failed: ${params.error}`);
     this.name = "OperationFailedError";
-    this.operationId = operationId;
-    this.operationError = error;
+    this.operationId = params.operationId;
+    this.operationError = params.error;
+    this.errorMessage = params.message;
+    this.category = params.category;
   }
 }
 
 export class OperationCancelledError extends XpozError {
-  operationId: string;
+  operationId?: string;
 
-  constructor(operationId: string) {
-    super(`Operation ${operationId} was cancelled`);
+  constructor(operationId?: string) {
+    const target = operationId ? `Operation ${operationId}` : "Operation";
+    super(`${target} was cancelled`);
     this.name = "OperationCancelledError";
     this.operationId = operationId;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { XpozClient } from "./client.js";
 export { PaginatedResult } from "./pagination.js";
+export { NoDataResult } from "./results.js";
 export {
   XpozError,
   AuthenticationError,

--- a/src/mcp/polling.ts
+++ b/src/mcp/polling.ts
@@ -11,7 +11,7 @@ export const RESPONSE_STATUS = {
   SUCCESS: "success",
   ERROR: "error",
   NO_DATA: "no_data",
-  IN_PROGRESS: "in_progress",
+  RUNNING: "running",
   CANCELLED: "cancelled",
 } as const;
 

--- a/src/mcp/polling.ts
+++ b/src/mcp/polling.ts
@@ -7,6 +7,46 @@ import {
 
 type CallTool = (name: string, args: Record<string, unknown>) => Promise<Record<string, unknown>>;
 
+export const RESPONSE_STATUS = {
+  SUCCESS: "success",
+  ERROR: "error",
+  NO_DATA: "no_data",
+  IN_PROGRESS: "in_progress",
+  CANCELLED: "cancelled",
+} as const;
+
+export function interpretStatus(
+  raw: Record<string, unknown>,
+  operationId?: string
+): Record<string, unknown> | null {
+  const status = raw["status"];
+
+  if (status === RESPONSE_STATUS.ERROR) {
+    throw new OperationFailedError({
+      error: String(raw["error"] ?? "Unknown error"),
+      operationId,
+      message: typeof raw["message"] === "string" ? raw["message"] : undefined,
+      category:
+        typeof raw["category"] === "string" ? raw["category"] : undefined,
+    });
+  }
+
+  if (status === RESPONSE_STATUS.CANCELLED) {
+    throw new OperationCancelledError(operationId);
+  }
+
+  if (
+    status === RESPONSE_STATUS.SUCCESS ||
+    status === RESPONSE_STATUS.NO_DATA ||
+    "results" in raw ||
+    "downloadUrl" in raw
+  ) {
+    return raw;
+  }
+
+  return null;
+}
+
 export async function waitForResult(
   callTool: CallTool,
   operationId: string,
@@ -16,24 +56,10 @@ export async function waitForResult(
 
   while (true) {
     const result = await callTool("checkOperationStatus", { operationId });
-    const status = result["status"];
 
-    if (status === "failed") {
-      const error = result["error"] ?? "Unknown error";
-      throw new OperationFailedError(operationId, String(error));
-    }
-
-    if (status === "cancelled") {
-      throw new OperationCancelledError(operationId);
-    }
-
-    if (
-      status === "completed" ||
-      status === "no_data" ||
-      "results" in result ||
-      "downloadUrl" in result
-    ) {
-      return result;
+    const terminal = interpretStatus(result, operationId);
+    if (terminal !== null) {
+      return terminal;
     }
 
     const elapsed = Date.now() - start;

--- a/src/namespaces/base.ts
+++ b/src/namespaces/base.ts
@@ -1,5 +1,6 @@
-import { waitForResult } from "../mcp/polling.js";
+import { interpretStatus, waitForResult } from "../mcp/polling.js";
 import { PaginatedResult } from "../pagination.js";
+import { NoDataResult } from "../results.js";
 import type { PaginationInfo } from "../types/common.js";
 import { DEFAULT_TIMEOUT_MS } from "../config/constants.js";
 
@@ -44,8 +45,9 @@ export class BaseNamespace {
   ): Promise<RawDict> {
     const result = await this.callTool(toolName, args);
 
-    if ("results" in result) {
-      return result;
+    const terminal = interpretStatus(result);
+    if (terminal !== null) {
+      return terminal;
     }
 
     const operationId = result["operationId"] as string | undefined;
@@ -61,7 +63,13 @@ export class BaseNamespace {
     parseItem: (item: RawDict) => T,
     toolName: string,
     baseArgs: RawDict
-  ): PaginatedResult<T> {
+  ): PaginatedResult<T> | NoDataResult {
+    if (raw["status"] === "no_data") {
+      return new NoDataResult(
+        typeof raw["message"] === "string" ? raw["message"] : ""
+      );
+    }
+
     const items = extractResults(raw).map(parseItem);
     const pagination = extractPagination(raw);
     const tableName = pagination.tableName;
@@ -70,7 +78,7 @@ export class BaseNamespace {
     const fetchPage = async (
       pageNumber: number,
       tbl: string | null | undefined
-    ): Promise<PaginatedResult<T>> => {
+    ): Promise<PaginatedResult<T> | NoDataResult> => {
       const args: RawDict = { ...baseArgs, pageNumber };
       if (tbl) args["tableName"] = tbl;
       const pageRaw = await this.callAndMaybePoll(toolName, args);

--- a/src/namespaces/instagram.ts
+++ b/src/namespaces/instagram.ts
@@ -1,5 +1,6 @@
 import { BaseNamespace } from "./base.js";
 import { PaginatedResult } from "../pagination.js";
+import { NoDataResult } from "../results.js";
 import type { InstagramPost, InstagramUser, InstagramComment } from "../types/instagram.js";
 import * as tools from "../config/tools.js";
 import { ResponseType } from "../config/constants.js";
@@ -39,7 +40,7 @@ export class InstagramNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<InstagramPost>> {
+  ): Promise<PaginatedResult<InstagramPost> | NoDataResult> {
     const args = this.buildArgs({
       identifier,
       identifierType: options.identifierType ?? "username",
@@ -69,7 +70,7 @@ export class InstagramNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<InstagramPost>> {
+  ): Promise<PaginatedResult<InstagramPost> | NoDataResult> {
     const args = this.buildArgs({
       query,
       fields: options.fields,
@@ -91,7 +92,7 @@ export class InstagramNamespace extends BaseNamespace {
       endDate?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<InstagramComment>> {
+  ): Promise<PaginatedResult<InstagramComment> | NoDataResult> {
     const args = this.buildArgs({ postId, ...options });
     const result = await this.callAndMaybePoll(tools.GET_INSTAGRAM_COMMENTS, args);
     return this.buildPaginatedResult(result, parseComment, tools.GET_INSTAGRAM_COMMENTS, args);
@@ -127,7 +128,7 @@ export class InstagramNamespace extends BaseNamespace {
     username: string,
     connectionType: string,
     options: { fields?: string[]; forceLatest?: boolean } = {}
-  ): Promise<PaginatedResult<InstagramUser>> {
+  ): Promise<PaginatedResult<InstagramUser> | NoDataResult> {
     const args = this.buildArgs({ username, connectionType, ...options });
     const result = await this.callAndMaybePoll(tools.GET_INSTAGRAM_USER_CONNECTIONS, args);
     return this.buildPaginatedResult(
@@ -142,7 +143,7 @@ export class InstagramNamespace extends BaseNamespace {
     postId: string,
     interactionType: string,
     options: { fields?: string[]; forceLatest?: boolean } = {}
-  ): Promise<PaginatedResult<InstagramUser>> {
+  ): Promise<PaginatedResult<InstagramUser> | NoDataResult> {
     const args = this.buildArgs({ postId, interactionType, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_INSTAGRAM_POST_INTERACTING_USERS,
@@ -166,7 +167,7 @@ export class InstagramNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<InstagramUser>> {
+  ): Promise<PaginatedResult<InstagramUser> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.GET_INSTAGRAM_USERS_BY_KEYWORDS, args);
     return this.buildPaginatedResult(

--- a/src/namespaces/reddit.ts
+++ b/src/namespaces/reddit.ts
@@ -1,5 +1,6 @@
 import { BaseNamespace } from "./base.js";
 import { PaginatedResult } from "../pagination.js";
+import { NoDataResult } from "../results.js";
 import type {
   RedditPost,
   RedditUser,
@@ -43,7 +44,7 @@ export class RedditNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<RedditPost>> {
+  ): Promise<PaginatedResult<RedditPost> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.SEARCH_REDDIT_POSTS, args);
     return this.buildPaginatedResult(result, parsePost, tools.SEARCH_REDDIT_POSTS, args);
@@ -70,7 +71,7 @@ export class RedditNamespace extends BaseNamespace {
       endDate?: string;
       subreddit?: string;
     } = {}
-  ): Promise<PaginatedResult<RedditComment>> {
+  ): Promise<PaginatedResult<RedditComment> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.SEARCH_REDDIT_COMMENTS, args);
     return this.buildPaginatedResult(result, parseComment, tools.SEARCH_REDDIT_COMMENTS, args);
@@ -107,7 +108,7 @@ export class RedditNamespace extends BaseNamespace {
       subreddit?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<RedditUser>> {
+  ): Promise<PaginatedResult<RedditUser> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.GET_REDDIT_USERS_BY_KEYWORDS, args);
     return this.buildPaginatedResult(
@@ -148,7 +149,7 @@ export class RedditNamespace extends BaseNamespace {
       endDate?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<RedditSubreddit>> {
+  ): Promise<PaginatedResult<RedditSubreddit> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.GET_REDDIT_SUBREDDITS_BY_KEYWORDS, args);
     return this.buildPaginatedResult(

--- a/src/namespaces/tiktok.ts
+++ b/src/namespaces/tiktok.ts
@@ -1,5 +1,6 @@
 import { BaseNamespace } from "./base.js";
 import { PaginatedResult } from "../pagination.js";
+import { NoDataResult } from "../results.js";
 import type { TiktokPost, TiktokUser, TiktokComment } from "../types/tiktok.js";
 import * as tools from "../config/tools.js";
 import { ResponseType } from "../config/constants.js";
@@ -39,7 +40,7 @@ export class TiktokNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TiktokPost>> {
+  ): Promise<PaginatedResult<TiktokPost> | NoDataResult> {
     const args = this.buildArgs({
       identifier,
       identifierType: options.identifierType ?? "username",
@@ -69,7 +70,7 @@ export class TiktokNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TiktokPost>> {
+  ): Promise<PaginatedResult<TiktokPost> | NoDataResult> {
     const args = this.buildArgs({
       query,
       fields: options.fields,
@@ -91,7 +92,7 @@ export class TiktokNamespace extends BaseNamespace {
       endDate?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<TiktokComment>> {
+  ): Promise<PaginatedResult<TiktokComment> | NoDataResult> {
     const args = this.buildArgs({ postId, ...options });
     const result = await this.callAndMaybePoll(tools.GET_TIKTOK_COMMENTS, args);
     return this.buildPaginatedResult(result, parseComment, tools.GET_TIKTOK_COMMENTS, args);
@@ -133,7 +134,7 @@ export class TiktokNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TiktokUser>> {
+  ): Promise<PaginatedResult<TiktokUser> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(tools.GET_TIKTOK_USERS_BY_KEYWORDS, args);
     return this.buildPaginatedResult(

--- a/src/namespaces/twitter.ts
+++ b/src/namespaces/twitter.ts
@@ -1,5 +1,6 @@
 import { BaseNamespace } from "./base.js";
 import { PaginatedResult } from "../pagination.js";
+import { NoDataResult } from "../results.js";
 import type { TwitterPost, TwitterUser } from "../types/twitter.js";
 import * as tools from "../config/tools.js";
 import { ResponseType } from "../config/constants.js";
@@ -37,7 +38,7 @@ export class TwitterNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TwitterPost>> {
+  ): Promise<PaginatedResult<TwitterPost> | NoDataResult> {
     const args = this.buildArgs({
       username: identifier,
       fields: options.fields,
@@ -73,7 +74,7 @@ export class TwitterNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TwitterPost>> {
+  ): Promise<PaginatedResult<TwitterPost> | NoDataResult> {
     const args = this.buildArgs({
       query,
       fields: options.fields,
@@ -121,7 +122,7 @@ export class TwitterNamespace extends BaseNamespace {
   async getRetweets(
     postId: string,
     options: { fields?: string[]; startDate?: string } = {}
-  ): Promise<PaginatedResult<TwitterPost>> {
+  ): Promise<PaginatedResult<TwitterPost> | NoDataResult> {
     const args = this.buildArgs({ postId, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_TWITTER_RETWEETS,
@@ -142,7 +143,7 @@ export class TwitterNamespace extends BaseNamespace {
       startDate?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<TwitterPost>> {
+  ): Promise<PaginatedResult<TwitterPost> | NoDataResult> {
     const args = this.buildArgs({ postId, ...options });
     const result = await this.callAndMaybePoll(tools.GET_TWITTER_QUOTES, args);
     return this.buildPaginatedResult(
@@ -160,7 +161,7 @@ export class TwitterNamespace extends BaseNamespace {
       startDate?: string;
       forceLatest?: boolean;
     } = {}
-  ): Promise<PaginatedResult<TwitterPost>> {
+  ): Promise<PaginatedResult<TwitterPost> | NoDataResult> {
     const args = this.buildArgs({ postId, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_TWITTER_COMMENTS,
@@ -178,7 +179,7 @@ export class TwitterNamespace extends BaseNamespace {
     postId: string,
     interactionType: string,
     options: { fields?: string[]; forceLatest?: boolean } = {}
-  ): Promise<PaginatedResult<TwitterUser>> {
+  ): Promise<PaginatedResult<TwitterUser> | NoDataResult> {
     const args = this.buildArgs({ postId, interactionType, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_TWITTER_POST_INTERACTING_USERS,
@@ -257,7 +258,7 @@ export class TwitterNamespace extends BaseNamespace {
     username: string,
     connectionType: string,
     options: { fields?: string[]; forceLatest?: boolean } = {}
-  ): Promise<PaginatedResult<TwitterUser>> {
+  ): Promise<PaginatedResult<TwitterUser> | NoDataResult> {
     const args = this.buildArgs({ username, connectionType, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_TWITTER_USER_CONNECTIONS,
@@ -282,7 +283,7 @@ export class TwitterNamespace extends BaseNamespace {
       responseType?: ResponseType;
       limit?: number;
     } = {}
-  ): Promise<PaginatedResult<TwitterUser>> {
+  ): Promise<PaginatedResult<TwitterUser> | NoDataResult> {
     const args = this.buildArgs({ query, ...options });
     const result = await this.callAndMaybePoll(
       tools.GET_TWITTER_USERS_BY_KEYWORDS,

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,6 +1,10 @@
 import type { PaginationInfo } from "./types/common.js";
+import { NoDataResult } from "./results.js";
 
-type FetchPage<T> = (pageNumber: number, tableName: string | null | undefined) => Promise<PaginatedResult<T>>;
+type FetchPage<T> = (
+  pageNumber: number,
+  tableName: string | null | undefined
+) => Promise<PaginatedResult<T> | NoDataResult>;
 type FetchExport = (exportOperationId: string) => Promise<string>;
 
 export class PaginatedResult<T> {
@@ -31,14 +35,16 @@ export class PaginatedResult<T> {
     return this.pagination.pageNumber < this.pagination.totalPages;
   }
 
-  async nextPage(): Promise<PaginatedResult<T>> {
+  async nextPage(): Promise<PaginatedResult<T> | NoDataResult> {
     if (!this.hasNextPage()) {
       throw new RangeError("No more pages available");
     }
     return this._fetchPageResult(this.pagination.pageNumber + 1);
   }
 
-  async getPage(pageNumber: number): Promise<PaginatedResult<T>> {
+  async getPage(
+    pageNumber: number
+  ): Promise<PaginatedResult<T> | NoDataResult> {
     if (pageNumber < 1 || pageNumber > this.pagination.totalPages) {
       throw new RangeError(
         `Page ${pageNumber} out of range (1-${this.pagination.totalPages})`
@@ -54,7 +60,9 @@ export class PaginatedResult<T> {
     return this._fetchExport(this._exportOperationId);
   }
 
-  private _fetchPageResult(pageNumber: number): Promise<PaginatedResult<T>> {
+  private _fetchPageResult(
+    pageNumber: number
+  ): Promise<PaginatedResult<T> | NoDataResult> {
     return this._fetchPage(pageNumber, this._tableName);
   }
 

--- a/src/results.ts
+++ b/src/results.ts
@@ -1,0 +1,8 @@
+export class NoDataResult {
+  readonly status = "no_data" as const;
+  readonly message: string;
+
+  constructor(message: string) {
+    this.message = message;
+  }
+}

--- a/tests/polling.test.ts
+++ b/tests/polling.test.ts
@@ -100,14 +100,14 @@ describe("interpretStatus", () => {
     expect(interpretStatus(raw)).toBe(raw);
   });
 
-  it("returns null on status=in_progress", () => {
+  it("returns null on status=running", () => {
     expect(
-      interpretStatus({ status: RESPONSE_STATUS.IN_PROGRESS, progress: 0.5 })
+      interpretStatus({ status: RESPONSE_STATUS.RUNNING, progress: 0.5 })
     ).toBeNull();
   });
 
   it("returns null on unknown status", () => {
-    expect(interpretStatus({ status: "running" })).toBeNull();
+    expect(interpretStatus({ status: "pending" })).toBeNull();
   });
 });
 
@@ -130,8 +130,8 @@ describe("waitForResult", () => {
   it("polls until success", async () => {
     vi.useFakeTimers();
     const { callTool, calls } = stubCallTool([
-      { status: "in_progress" },
-      { status: "in_progress" },
+      { status: "running" },
+      { status: "running" },
       { status: "success", results: [{ id: 1 }] },
     ]);
     const promise = waitForResult(callTool, "op_xxx", 60_000);
@@ -161,8 +161,8 @@ describe("waitForResult", () => {
   it("throws OperationTimeoutError when elapsed exceeds timeout", async () => {
     vi.useFakeTimers();
     const { callTool } = stubCallTool([
-      { status: "in_progress" },
-      { status: "in_progress" },
+      { status: "running" },
+      { status: "running" },
     ]);
     const caught = waitForResult(callTool, "op_xxx", 1_000).catch(
       (e: unknown) => e
@@ -236,8 +236,8 @@ describe("callAndMaybePoll (sync response path)", () => {
   it("polls async operation and returns eventual result", async () => {
     vi.useFakeTimers();
     const { callTool, calls } = stubCallTool([
-      { operationId: "op_xxx", status: "in_progress" },
-      { status: "in_progress" },
+      { operationId: "op_xxx", status: "running" },
+      { status: "running" },
       { status: "success", results: [{ id: 42 }] },
     ]);
     const ns = new TestNamespace(callTool, 60_000);

--- a/tests/polling.test.ts
+++ b/tests/polling.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  interpretStatus,
+  waitForResult,
+  RESPONSE_STATUS,
+} from "../src/mcp/polling.js";
+import {
+  OperationCancelledError,
+  OperationFailedError,
+  OperationTimeoutError,
+} from "../src/errors.js";
+import { BaseNamespace } from "../src/namespaces/base.js";
+import { PaginatedResult } from "../src/pagination.js";
+import { NoDataResult } from "../src/results.js";
+
+type CallTool = (
+  name: string,
+  args: Record<string, unknown>
+) => Promise<Record<string, unknown>>;
+
+function stubCallTool(responses: Record<string, unknown>[]): {
+  callTool: CallTool;
+  calls: { name: string; args: Record<string, unknown> }[];
+} {
+  const queue = [...responses];
+  const calls: { name: string; args: Record<string, unknown> }[] = [];
+  const callTool: CallTool = async (name, args) => {
+    calls.push({ name, args });
+    const next = queue.shift();
+    if (next === undefined) {
+      throw new Error("stubCallTool: no more responses");
+    }
+    return next;
+  };
+  return { callTool, calls };
+}
+
+describe("interpretStatus", () => {
+  it("raises OperationFailedError with all attrs on status=error", () => {
+    const raw = {
+      status: RESPONSE_STATUS.ERROR,
+      error: "Operation not found",
+      message: "No operation found with ID: op_xxx",
+      category: "internal",
+    };
+    try {
+      interpretStatus(raw, "op_xxx");
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OperationFailedError);
+      const failed = err as OperationFailedError;
+      expect(failed.operationId).toBe("op_xxx");
+      expect(failed.operationError).toBe("Operation not found");
+      expect(failed.errorMessage).toBe("No operation found with ID: op_xxx");
+      expect(failed.category).toBe("internal");
+    }
+  });
+
+  it("raises OperationFailedError without operationId on sync error", () => {
+    const raw = {
+      status: RESPONSE_STATUS.ERROR,
+      error: "Empty query",
+      category: "validation",
+    };
+    try {
+      interpretStatus(raw);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OperationFailedError);
+      const failed = err as OperationFailedError;
+      expect(failed.operationId).toBeUndefined();
+      expect(failed.category).toBe("validation");
+      expect(failed.message).toContain("Operation failed: Empty query");
+    }
+  });
+
+  it("raises OperationCancelledError on status=cancelled", () => {
+    expect(() =>
+      interpretStatus({ status: RESPONSE_STATUS.CANCELLED }, "op_xxx")
+    ).toThrow(OperationCancelledError);
+  });
+
+  it("returns raw dict on status=success", () => {
+    const raw = { status: RESPONSE_STATUS.SUCCESS, results: [{ id: 1 }] };
+    expect(interpretStatus(raw)).toBe(raw);
+  });
+
+  it("returns raw dict on status=no_data", () => {
+    const raw = { status: RESPONSE_STATUS.NO_DATA, message: "no matches" };
+    expect(interpretStatus(raw)).toBe(raw);
+  });
+
+  it("returns raw dict when results key present without status", () => {
+    const raw = { results: [] as unknown[] };
+    expect(interpretStatus(raw)).toBe(raw);
+  });
+
+  it("returns raw dict when downloadUrl key present", () => {
+    const raw = { downloadUrl: "https://example.com/f.csv" };
+    expect(interpretStatus(raw)).toBe(raw);
+  });
+
+  it("returns null on status=in_progress", () => {
+    expect(
+      interpretStatus({ status: RESPONSE_STATUS.IN_PROGRESS, progress: 0.5 })
+    ).toBeNull();
+  });
+
+  it("returns null on unknown status", () => {
+    expect(interpretStatus({ status: "running" })).toBeNull();
+  });
+});
+
+describe("waitForResult", () => {
+  it("throws OperationFailedError on first error response", async () => {
+    const { callTool, calls } = stubCallTool([
+      {
+        status: "error",
+        error: "Tool execution failed",
+        message: "crawler timeout",
+        category: "internal",
+      },
+    ]);
+    await expect(waitForResult(callTool, "op_xxx", 10_000)).rejects.toThrow(
+      OperationFailedError
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  it("polls until success", async () => {
+    vi.useFakeTimers();
+    const { callTool, calls } = stubCallTool([
+      { status: "in_progress" },
+      { status: "in_progress" },
+      { status: "success", results: [{ id: 1 }] },
+    ]);
+    const promise = waitForResult(callTool, "op_xxx", 60_000);
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await promise;
+    expect(result["results"]).toEqual([{ id: 1 }]);
+    expect(calls).toHaveLength(3);
+    vi.useRealTimers();
+  });
+
+  it("returns raw dict on no_data", async () => {
+    const { callTool } = stubCallTool([
+      { status: "no_data", message: "no matches" },
+    ]);
+    const result = await waitForResult(callTool, "op_xxx", 10_000);
+    expect(result["status"]).toBe("no_data");
+    expect(result["message"]).toBe("no matches");
+  });
+
+  it("throws OperationCancelledError on cancelled", async () => {
+    const { callTool } = stubCallTool([{ status: "cancelled" }]);
+    await expect(waitForResult(callTool, "op_xxx", 10_000)).rejects.toThrow(
+      OperationCancelledError
+    );
+  });
+
+  it("throws OperationTimeoutError when elapsed exceeds timeout", async () => {
+    vi.useFakeTimers();
+    const { callTool } = stubCallTool([
+      { status: "in_progress" },
+      { status: "in_progress" },
+    ]);
+    const caught = waitForResult(callTool, "op_xxx", 1_000).catch(
+      (e: unknown) => e
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    const err = await caught;
+    expect(err).toBeInstanceOf(OperationTimeoutError);
+    vi.useRealTimers();
+  });
+});
+
+class TestNamespace extends BaseNamespace {
+  async invoke(toolName: string, args: Record<string, unknown>) {
+    return this.callAndMaybePoll(toolName, args);
+  }
+
+  build(
+    raw: Record<string, unknown>,
+    toolName: string,
+    baseArgs: Record<string, unknown>
+  ) {
+    return this.buildPaginatedResult(
+      raw,
+      (item) => item,
+      toolName,
+      baseArgs
+    );
+  }
+}
+
+describe("callAndMaybePoll (sync response path)", () => {
+  it("raises OperationFailedError on sync error without operationId", async () => {
+    const { callTool, calls } = stubCallTool([
+      {
+        status: "error",
+        error: "Empty query",
+        message: "Query cannot be empty",
+        category: "validation",
+      },
+    ]);
+    const ns = new TestNamespace(callTool, 10_000);
+    await expect(
+      ns.invoke("getRedditPostsByKeywords", { query: "" })
+    ).rejects.toMatchObject({
+      name: "OperationFailedError",
+      operationError: "Empty query",
+      category: "validation",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns sync success result", async () => {
+    const { callTool } = stubCallTool([
+      { status: "success", results: [{ id: 1 }] },
+    ]);
+    const ns = new TestNamespace(callTool, 10_000);
+    const result = await ns.invoke("someTool", {});
+    expect(result["results"]).toEqual([{ id: 1 }]);
+  });
+
+  it("returns sync no_data result", async () => {
+    const { callTool } = stubCallTool([
+      { status: "no_data", message: "empty" },
+    ]);
+    const ns = new TestNamespace(callTool, 10_000);
+    const result = await ns.invoke("someTool", {});
+    expect(result["status"]).toBe("no_data");
+    expect(result["message"]).toBe("empty");
+  });
+
+  it("polls async operation and returns eventual result", async () => {
+    vi.useFakeTimers();
+    const { callTool, calls } = stubCallTool([
+      { operationId: "op_xxx", status: "in_progress" },
+      { status: "in_progress" },
+      { status: "success", results: [{ id: 42 }] },
+    ]);
+    const ns = new TestNamespace(callTool, 60_000);
+    const promise = ns.invoke("someTool", {});
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await promise;
+    expect(result["results"]).toEqual([{ id: 42 }]);
+    expect(calls).toHaveLength(3);
+    vi.useRealTimers();
+  });
+});
+
+describe("buildPaginatedResult (NoDataResult)", () => {
+  it("returns NoDataResult when status is no_data", () => {
+    const { callTool } = stubCallTool([]);
+    const ns = new TestNamespace(callTool, 10_000);
+    const raw = { status: "no_data", message: "no matches for query" };
+    const result = ns.build(raw, "searchRedditPosts", {});
+    expect(result).toBeInstanceOf(NoDataResult);
+    if (result instanceof NoDataResult) {
+      expect(result.status).toBe("no_data");
+      expect(result.message).toBe("no matches for query");
+    }
+  });
+
+  it("returns PaginatedResult when status is success", () => {
+    const { callTool } = stubCallTool([]);
+    const ns = new TestNamespace(callTool, 10_000);
+    const raw = {
+      status: "success",
+      results: [{ id: 1 }],
+      pagination: {
+        tableName: "t_xxx",
+        totalRows: 1,
+        totalPages: 1,
+        pageNumber: 1,
+        pageSize: 100,
+        resultsCount: 1,
+      },
+    };
+    const result = ns.build(raw, "searchRedditPosts", {});
+    expect(result).toBeInstanceOf(PaginatedResult);
+  });
+});


### PR DESCRIPTION
## Summary

Three coupled fixes to how the TypeScript SDK interprets MCP wire-level `ResponseStatus` values (`success` | `error` | `no_data` | `running` | `cancelled`).

### 1. `status=error` handling — ENG-1584

The polling loop branched on `status=failed` (internal `OPERATION_STATUS`), but the wire emits `status=error`. Real backend failures fell through terminal checks and eventually threw `OperationTimeoutError` after 600s — hiding validation / auth / usage-limit / internal errors.

- Adds `interpretStatus` helper in `src/mcp/polling.ts` that throws `OperationFailedError` with MCP-provided `error` / `message` / `category`.
- `OperationFailedError` widened: constructor now takes a named-params object, `operationId` optional, new `errorMessage` + `category` fields.

### 2. Sync error handling — ENG-1585

`callAndMaybePoll` only handled `"results" in result` and `operationId` branches. Sync error responses fell through and were coerced into empty paginated results. Now calls `interpretStatus` at the top of the chokepoint too.

### 3. `NoDataResult` discriminated return type — ENG-1586 (breaking)

`status=no_data` was coerced into an empty `PaginatedResult`, losing the MCP-provided `message` and making "zero results" indistinguishable from "empty last page".

- New public `NoDataResult { status: "no_data", message: string }` class in `src/results.ts`, exported from `src/index.ts`.
- `buildPaginatedResult` early-returns `NoDataResult` on `no_data`.
- Every search-style namespace method widened: `Promise<PaginatedResult<T>>` → `Promise<PaginatedResult<T> | NoDataResult>` (22 methods across twitter / instagram / reddit / tiktok).
- `PaginatedResult.nextPage()` / `getPage()` widened to match.

Callers must narrow via the `status` discriminator or `instanceof NoDataResult` before accessing `.data`.

## Companion PR

[xpoz-mcp #458](https://github.com/hossenco/xpoz-mcp/pull/458) aligns the MCP server. The wire value for running operations stays `'running'` (unchanged from pre-eng-1517 main), so clients branching on `status === "running"` still work.

## Test plan

- [x] `npx vitest run tests/polling.test.ts` — 20 new mock-based unit tests (first in this repo) pass
- [x] `npm run build` — tsup dual CJS+ESM+dts build succeeds
- [ ] `npm test` against live Xpoz API — `success` / `no_data` paths work for each platform
- [ ] Manual: trigger a sync error via the SDK and confirm `OperationFailedError` throws immediately instead of after 300s

Closes ENG-1584, ENG-1585, ENG-1586