### PR TITLE
ENG-1584/1585: align polling with new MCP wire schema

### DIFF
--- a/src/mcp/polling.ts
+++ b/src/mcp/polling.ts
@@ -18,7 +18,7 @@ export async function waitForResult(
     const result = await callTool("checkOperationStatus", { operationId });
     const status = result["status"];
 
-    if (status === "failed") {
+    if (status === "error") {
       const error = result["error"] ?? "Unknown error";
       throw new OperationFailedError(operationId, String(error));
     }
@@ -28,7 +28,7 @@ export async function waitForResult(
     }
 
     if (
-      status === "completed" ||
+      status === "success" ||
       status === "no_data" ||
       "results" in result ||
       "downloadUrl" in result

--- a/src/namespaces/base.ts
+++ b/src/namespaces/base.ts
@@ -2,6 +2,7 @@ import { waitForResult } from "../mcp/polling.js";
 import { PaginatedResult } from "../pagination.js";
 import type { PaginationInfo } from "../types/common.js";
 import { DEFAULT_TIMEOUT_MS } from "../config/constants.js";
+import { OperationFailedError } from "../errors.js";
 
 type CallTool = (
   name: string,
@@ -44,7 +45,15 @@ export class BaseNamespace {
   ): Promise<RawDict> {
     const result = await this.callTool(toolName, args);
 
-    if ("results" in result) {
+    // if receiving error in first call it is a sync call.
+    if (result["status"] === "error") {
+      throw new OperationFailedError(
+        "",
+        String(result["error"] ?? "Unknown error")
+      );
+    }
+
+    if (result["status"] === "success" || "results" in result) {
       return result;
     }
 

--- a/tests/polling.test.ts
+++ b/tests/polling.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OperationCancelledError,
+  OperationFailedError,
+} from "../src/errors.js";
+import { waitForResult } from "../src/mcp/polling.js";
+import { BaseNamespace } from "../src/namespaces/base.js";
+
+type RawDict = Record<string, unknown>;
+type CallTool = (name: string, args: RawDict) => Promise<RawDict>;
+
+function mockCallTool(responses: RawDict[]): CallTool {
+  let i = 0;
+  return async () => {
+    if (i >= responses.length) {
+      throw new Error("mockCallTool: no more responses queued");
+    }
+    return responses[i++];
+  };
+}
+
+class TestNamespace extends BaseNamespace {
+  async run(toolName: string, args: RawDict): Promise<RawDict> {
+    return this.callAndMaybePoll(toolName, args);
+  }
+}
+
+describe("waitForResult", () => {
+  it("throws OperationFailedError on status: error", async () => {
+    const mock = mockCallTool([
+      { status: "error", error: "Operation not found", category: "internal" },
+    ]);
+    await expect(waitForResult(mock, "op_abc", 10_000)).rejects.toMatchObject({
+      name: "OperationFailedError",
+      operationId: "op_abc",
+      operationError: "Operation not found",
+    });
+  });
+
+  it("returns on status: success", async () => {
+    const response = {
+      status: "success",
+      results: [{ id: "1" }],
+      pagination: {},
+    };
+    const mock = mockCallTool([response]);
+    await expect(waitForResult(mock, "op_abc", 10_000)).resolves.toEqual(
+      response
+    );
+  });
+
+  it("throws OperationCancelledError on status: cancelled", async () => {
+    const mock = mockCallTool([{ status: "cancelled" }]);
+    await expect(waitForResult(mock, "op_abc", 10_000)).rejects.toBeInstanceOf(
+      OperationCancelledError
+    );
+  });
+});
+
+describe("callAndMaybePoll", () => {
+  it("throws OperationFailedError on sync status: error", async () => {
+    const mock = mockCallTool([
+      { status: "error", error: "Empty query", category: "validation" },
+    ]);
+    const ns = new TestNamespace(mock, 10_000);
+    await expect(ns.run("getRedditPostsByKeywords", {})).rejects.toMatchObject({
+      name: "OperationFailedError",
+      operationId: "",
+      operationError: "Empty query",
+    });
+  });
+
+  it("polls when operationId present and returns success", async () => {
+    const mock = mockCallTool([
+      { operationId: "op_x" },
+      { status: "success", results: [{ id: "1" }] },
+    ]);
+    const ns = new TestNamespace(mock, 10_000);
+    const result = await ns.run("getTwitterPostsByKeywords", {});
+    expect(result["results"]).toEqual([{ id: "1" }]);
+  });
+
+  it("returns sync success with results unchanged", async () => {
+    const mock = mockCallTool([{ results: [{ id: "1" }] }]);
+    const ns = new TestNamespace(mock, 10_000);
+    const result = await ns.run("searchTwitterUsers", {});
+    expect(result["results"]).toEqual([{ id: "1" }]);
+  });
+
+  it("thrown OperationFailedError is catchable as Error", async () => {
+    const mock = mockCallTool([{ status: "error", error: "Crawler failed" }]);
+    const ns = new TestNamespace(mock, 10_000);
+    try {
+      await ns.run("getTwitterPostsByAuthor", {});
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationFailedError);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Polling loop: swap status checks from `"failed"`/`"completed"` to `"error"`/`"success"` per xpoz-mcp ENG-1517 wire schema (`ResponseStatus = {SUCCESS, ERROR, NO_DATA, RUNNING, CANCELLED}`)
- `callAndMaybePoll`: raise `OperationFailedError` on sync `status: "error"` responses instead of silently returning an empty `PaginatedResult` (ENG-1585)
- Also treat `status: "success"` as a terminal sync response (new schema nests `results` under `data`)
- Add unit tests for both chokepoints — mock-based, no API key required

Ships with / after xpoz-mcp ENG-1517 merges to main. On current xpoz-mcp main the polling loop is already dead-code broken against the real wire; this fix lights up once ENG-1517 lands.

Follow-up ticket: introduce `ToolError` base class, centralize status constants, propagate wire `category`/`message` as exception attributes (currently dropped — `.operationError` carries only the `error` label).

## Test plan

- [x] `npx vitest run tests/polling.test.ts` passes (7 tests)
- [x] `npm run typecheck` clean on changed files (pre-existing `undici` error unrelated)
- [ ] Against xpoz-mcp on ENG-1517 branch: calling with bad op id raises within one poll cycle (not 300 s timeout)
- [ ] Against xpoz-mcp on ENG-1517 branch: Reddit search with empty query raises `OperationFailedError` synchronously (not empty `PaginatedResult`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)