### PR TITLE
ENG-1585: Handle no_data status explicitly in callAndMaybePoll

### DIFF
--- a/src/namespaces/base.ts
+++ b/src/namespaces/base.ts
@@ -53,7 +53,7 @@ export class BaseNamespace {
       );
     }
 
-    if (result["status"] === "success" || "results" in result) {
+    if (result["status"] === "success" || result["status"] === "no_data" || "results" in result) {
       return result;
     }
 


### PR DESCRIPTION
## Summary
- Add explicit `no_data` terminal status check in `callAndMaybePoll` to match the polling loop
- Prevents an unnecessary polling round-trip when a `no_data` response includes an `operationId`

## Test plan
- [ ] Run `npm test` — no behavioral change for existing flows
- [ ] Verify `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)