### PR TITLE
feat: add Hashtag to TrackedItemType enum

### DIFF
--- a/src/types/tracking.ts
+++ b/src/types/tracking.ts
@@ -2,6 +2,7 @@ export enum TrackedItemType {
   Keyword = "keyword",
   User = "user",
   Subreddit = "subreddit",
+  Hashtag = "hashtag",
 }
 
 export enum TrackedItemPlatform {


### PR DESCRIPTION
## Summary
- Add `Hashtag = "hashtag"` to `TrackedItemType` enum to support TikTok hashtag tracking
- Matches the xpoz-mcp server update (hossenco/xpoz-mcp#564)

Closes ENG-1727

## Test plan
- [x] Tested locally: `addTrackedItems` with `type: "hashtag", platform: "tiktok"` returns `addedCount: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)