### PR TITLE
feat: add forceLatest to getUser across all networks (ENG-1739)

### DIFF
--- a/src/namespaces/instagram.ts
+++ b/src/namespaces/instagram.ts
@@ -99,12 +99,13 @@ export class InstagramNamespace extends BaseNamespace {
 
   async getUser(
     identifier: string,
-    options: { identifierType?: string; fields?: string[] } = {}
+    options: { identifierType?: string; fields?: string[]; forceLatest?: boolean } = {}
   ): Promise<InstagramUser> {
     const args = this.buildArgs({
       identifier,
       identifierType: options.identifierType ?? "username",
       fields: options.fields,
+      forceLatest: options.forceLatest,
     });
     const result = await this.callAndMaybePoll(tools.GET_INSTAGRAM_USER, args);
     const results = result["results"];

--- a/src/namespaces/reddit.ts
+++ b/src/namespaces/reddit.ts
@@ -78,7 +78,7 @@ export class RedditNamespace extends BaseNamespace {
 
   async getUser(
     username: string,
-    options: { fields?: string[] } = {}
+    options: { fields?: string[]; forceLatest?: boolean } = {}
   ): Promise<RedditUser> {
     const args = this.buildArgs({ username, ...options });
     const result = await this.callAndMaybePoll(tools.GET_REDDIT_USER, args);

--- a/src/namespaces/tiktok.ts
+++ b/src/namespaces/tiktok.ts
@@ -99,12 +99,13 @@ export class TiktokNamespace extends BaseNamespace {
 
   async getUser(
     identifier: string,
-    options: { identifierType?: string; fields?: string[] } = {}
+    options: { identifierType?: string; fields?: string[]; forceLatest?: boolean } = {}
   ): Promise<TiktokUser> {
     const args = this.buildArgs({
       identifier,
       identifierType: options.identifierType ?? "username",
       fields: options.fields,
+      forceLatest: options.forceLatest,
     });
     const result = await this.callAndMaybePoll(tools.GET_TIKTOK_USER, args);
     const results = result["results"];

--- a/src/namespaces/twitter.ts
+++ b/src/namespaces/twitter.ts
@@ -226,12 +226,13 @@ export class TwitterNamespace extends BaseNamespace {
 
   async getUser(
     identifier: string,
-    options: { identifierType?: string; fields?: string[] } = {}
+    options: { identifierType?: string; fields?: string[]; forceLatest?: boolean } = {}
   ): Promise<TwitterUser> {
     const args = this.buildArgs({
       identifier,
       identifierType: options.identifierType ?? "username",
       fields: options.fields,
+      forceLatest: options.forceLatest,
     });
     const result = await this.callAndMaybePoll(tools.GET_TWITTER_USER, args);
     const results = result["results"];


### PR DESCRIPTION
## Summary
- Added `forceLatest?: boolean` to the options object of `getUser()` for all four namespaces (Twitter, Instagram, Reddit, TikTok)
- Reddit passes through via `...options` spread; others explicitly pass `forceLatest: options.forceLatest`

## Test plan
- [x] `npm run build` passes (ESM + CJS + .d.ts)
- [x] `forceLatest?: boolean` confirmed in all four `getUser` type declarations in `dist/index.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)