### PR TITLE
feat: add transcriptsJson field to tiktok post

### DIFF
--- a/src/types/tiktok.ts
+++ b/src/types/tiktok.ts
@@ -17,6 +17,7 @@ export interface TiktokPost {
   hashtags?: string[] | null;
   duration?: number | null;
   videoUrl?: string[] | null;
+  transcriptsJson?: Record<string, string> | null;
   createdAt?: string | null;
   createdAtTimestamp?: number | null;
   createdAtDate?: string | null;


### PR DESCRIPTION
## Summary
Adds the new `transcriptsJson` field to the `TiktokPost` interface, mirroring the server change in xpoz-mcp ([#581](https://github.com/hossenco/xpoz-mcp/pull/581)). This resolves the SDK compatibility warning:

> `[@xpoz/xpoz (TypeScript)] fields: Field "transcriptsJson" in tiktok.post exists on server but not in SDK's tiktok.post`

## Changes
- `TiktokPost` interface: added `transcriptsJson?: Record<string, string> | null` — a language-keyed object of video transcripts (e.g. `{ "en": "...", "nl": "..." }`).

## Verification
- `npm run typecheck` ✅
- Expectations regenerated and committed to xpoz-mcp ([#581](https://github.com/hossenco/xpoz-mcp/pull/581)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)