### PR TITLE
feat: add getCreditsUsageHistory to account namespace (ENG-1672)

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -47,3 +47,4 @@ export const ADD_TRACKED_ITEMS = "addTrackedItems";
 export const REMOVE_TRACKED_ITEMS = "removeTrackedItems";
 
 export const GET_ACCOUNT_DETAILS = "getAccountDetails";
+export const GET_CREDITS_USAGE_HISTORY = "getCreditsUsageHistory";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,11 @@ export type { TiktokPost, TiktokUser, TiktokComment } from "./types/tiktok.js";
 export { TrackedItemType, TrackedItemPlatform } from "./types/tracking.js";
 export type { TrackedItem, AddTrackedItemsResult, RemoveTrackedItemsResult } from "./types/tracking.js";
 export { BillingPeriod, CreditResetFrequency } from "./types/account.js";
-export type { AccountDetails, AccountBilling, AccountUsage, PlanFeatures } from "./types/account.js";
+export type {
+  AccountDetails,
+  AccountBilling,
+  AccountUsage,
+  PlanFeatures,
+  CreditsUsageHistory,
+  UsageHistoryBucket,
+} from "./types/account.js";

--- a/src/namespaces/account.ts
+++ b/src/namespaces/account.ts
@@ -1,10 +1,19 @@
 import { BaseNamespace } from "./base.js";
-import type { AccountDetails } from "../types/account.js";
+import type { AccountDetails, CreditsUsageHistory } from "../types/account.js";
 import * as tools from "../config/tools.js";
 
 export class AccountNamespace extends BaseNamespace {
   async getAccountDetails(): Promise<AccountDetails> {
     const result = await this.callTool(tools.GET_ACCOUNT_DETAILS, {});
     return result["data"] as AccountDetails;
+  }
+
+  async getCreditsUsageHistory(
+    range?: string,
+    granularity?: string
+  ): Promise<CreditsUsageHistory> {
+    const args = this.buildArgs({ range, granularity });
+    const result = await this.callTool(tools.GET_CREDITS_USAGE_HISTORY, args);
+    return result["data"] as CreditsUsageHistory;
   }
 }

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -38,3 +38,19 @@ export interface AccountDetails {
   billing: AccountBilling | null;
   usage: AccountUsage;
 }
+
+export interface UsageHistoryBucket {
+  bucket: string;
+  subscriptionUsed: number;
+  extraUsed: number;
+  totalUsed: number;
+  extraPurchased: number;
+}
+
+export interface CreditsUsageHistory {
+  range: string;
+  granularity: string;
+  generatedAt: string;
+  credits: UsageHistoryBucket[];
+  exportRows: UsageHistoryBucket[];
+}


### PR DESCRIPTION
## What

Mirrors the new xpoz-mcp `getCreditsUsageHistory` MCP tool ([ENG-1672](https://linear.app/xpoz/issue/ENG-1672), server side merged in hossenco/xpoz-mcp#595) in the TypeScript SDK.

- `AccountNamespace.getCreditsUsageHistory(range?, granularity?)` → `Promise<CreditsUsageHistory>`
- New types: `CreditsUsageHistory`, `UsageHistoryBucket` (exported from `index.ts`)
- New tool const `GET_CREDITS_USAGE_HISTORY`

`range`: `"today" | "7d" | "current_month" | "lifetime"` (default current_month). `granularity`: `"hour" | "day"` (default day). Returns `{ range, granularity, generatedAt, credits[], exportRows[] }` where each bucket has `subscriptionUsed`/`extraUsed`/`totalUsed`/`extraPurchased`. Follows the existing `getAccountDetails` pattern (plain `string` params, matching the SDK convention).

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)