### PR TITLE
feat: add TikTok sounds tools + document account namespace (ENG-1715)

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -41,6 +41,8 @@ export const GET_TIKTOK_USER = "getTiktokUser";
 export const SEARCH_TIKTOK_USERS = "searchTiktokUsers";
 export const GET_TIKTOK_USERS_BY_KEYWORDS = "getTiktokUsersByKeywords";
 export const GET_TIKTOK_USERS_BY_HASHTAGS = "getTiktokUsersByHashtags";
+export const SEARCH_TIKTOK_SOUNDS = "searchTiktokSounds";
+export const GET_TIKTOK_POSTS_BY_SOUND = "getTiktokPostsBySound";
 
 export const GET_TRACKED_ITEMS = "getTrackedItems";
 export const ADD_TRACKED_ITEMS = "addTrackedItems";

--- a/src/namespaces/tiktok.ts
+++ b/src/namespaces/tiktok.ts
@@ -1,6 +1,6 @@
 import { BaseNamespace } from "./base.js";
 import { PaginatedResult } from "../pagination.js";
-import type { TiktokPost, TiktokUser, TiktokComment } from "../types/tiktok.js";
+import type { TiktokPost, TiktokUser, TiktokComment, TiktokSound } from "../types/tiktok.js";
 import * as tools from "../config/tools.js";
 import { ResponseType } from "../config/constants.js";
 
@@ -16,6 +16,10 @@ function parseUser(item: RawDict): TiktokUser {
 
 function parseComment(item: RawDict): TiktokComment {
   return item as TiktokComment;
+}
+
+function parseSound(item: RawDict): TiktokSound {
+  return item as TiktokSound;
 }
 
 export class TiktokNamespace extends BaseNamespace {
@@ -185,5 +189,30 @@ export class TiktokNamespace extends BaseNamespace {
       tools.GET_TIKTOK_USERS_BY_HASHTAGS,
       args
     );
+  }
+
+  async searchSounds(
+    keyword: string,
+    options: { limit?: number; fields?: string[] } = {}
+  ): Promise<TiktokSound[]> {
+    const args = this.buildArgs({ keyword, ...options });
+    const result = await this.callAndMaybePoll(tools.SEARCH_TIKTOK_SOUNDS, args);
+    return ((result["results"] as RawDict[]) ?? []).map(parseSound);
+  }
+
+  async getPostsBySound(
+    soundId: string,
+    options: {
+      fields?: string[];
+      startDate?: string;
+      endDate?: string;
+      forceLatest?: boolean;
+      responseType?: ResponseType;
+      limit?: number;
+    } = {}
+  ): Promise<PaginatedResult<TiktokPost>> {
+    const args = this.buildArgs({ soundId, ...options });
+    const result = await this.callAndMaybePoll(tools.GET_TIKTOK_POSTS_BY_SOUND, args);
+    return this.buildPaginatedResult(result, parsePost, tools.GET_TIKTOK_POSTS_BY_SOUND, args);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export type {
   RedditPostWithComments,
   SubredditWithPosts,
 } from "./reddit.js";
-export type { TiktokPost, TiktokUser, TiktokComment } from "./tiktok.js";
+export type { TiktokPost, TiktokUser, TiktokComment, TiktokSound } from "./tiktok.js";
 export { TrackedItemType, TrackedItemPlatform } from "./tracking.js";
 export type { TrackedItem, AddTrackedItemsResult, RemoveTrackedItemsResult } from "./tracking.js";
 export { BillingPeriod, CreditResetFrequency } from "./account.js";

--- a/src/types/tiktok.ts
+++ b/src/types/tiktok.ts
@@ -62,3 +62,16 @@ export interface TiktokComment {
   createdAtDate?: string | null;
   [key: string]: unknown;
 }
+
+export interface TiktokSound {
+  id?: string | null;
+  title?: string | null;
+  author?: string | null;
+  album?: string | null;
+  duration?: number | null;
+  userCount?: number | null;
+  isOriginal?: boolean | null;
+  isCommerceMusic?: boolean | null;
+  isOriginalSound?: boolean | null;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary

**TikTok sounds tools (ENG-1715):**
- Add `TiktokSound` interface to `types/tiktok.ts`, exported from `types/index.ts`
- Add `SEARCH_TIKTOK_SOUNDS` / `GET_TIKTOK_POSTS_BY_SOUND` constants
- Add `parseSound` helper and `searchSounds()` / `getPostsBySound()` to `TiktokNamespace`

**Bug fix:**
- Export `CreditsUsageHistory` and `UsageHistoryBucket` from the package root — `getCreditsUsageHistory()` returns `CreditsUsageHistory` but the type was not exported, so consumers could not name the return type

**Docs:**
- Document the sounds methods + `TiktokSound` type model in README
- Document the previously-undocumented `client.account` namespace (`getAccountDetails`, `getCreditsUsageHistory`) with all account/usage type models
- Bump data-method count 40 → 42

## Test plan

- [x] `npm run build` passes
- [x] `import type { TiktokSound, CreditsUsageHistory } from "@xpoz/xpoz"` resolves
- [ ] `client.account.getCreditsUsageHistory("7d", "day")` returns `CreditsUsageHistory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)