### PR TITLE
docs: document required source field for trial token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ const client = new XpozClient({ apiKey: "your-api-key", timeoutMs: 600_000 });
 Want to try the SDK before signing up? Mint a free trial token (no account needed, valid for 5 days):
 
 ```bash
-curl -X POST https://api.xpoz.ai/api/trial/token
+curl -X POST https://api.xpoz.ai/api/trial/token \
+  -H "Content-Type: application/json" \
+  -d '{"source": "sdk"}'
 # -> { "success": true, "data": { "accessKey": "TRIAL...", "expiresInSeconds": 432000 }, ... }
 ```
+
+The `source` field is required — it identifies where the trial token request came from (e.g. `skills`, a specific page, `sdk`, `cli`).
 
 Then use the returned token (it starts with `TRIAL`) as your API key:
 


### PR DESCRIPTION
Documents the newly required `source` JSON body field for `POST /api/trial/token`.

- Updated the trial-token curl example to send `{"source": "sdk"}` with a JSON content-type header.
- Added a sentence explaining that `source` is required and identifies the origin of the request (e.g. `skills`, a specific page, `sdk`, `cli`).

Docs-only change; no code touched.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)